### PR TITLE
Robotics challenge launch fixes

### DIFF
--- a/launch/robotics_challenge.launch
+++ b/launch/robotics_challenge.launch
@@ -50,7 +50,7 @@
 	
 	<!--Start the Montecarlo Localization module-->
 	<node pkg="amcl" type="amcl" name="amcl" args="scan:=/scan">
-		<param name="initial_pose_x" value="$(arg init_x" /> 
+		<param name="initial_pose_x" value="$(arg init_x)" /> 
         <param name="initial_pose_y" value="$(arg init_y)" />
 		<param name="initial_pose_a" value="0" />
 	</node>

--- a/launch/robotics_challenge.launch
+++ b/launch/robotics_challenge.launch
@@ -29,8 +29,8 @@
 	</include>
 
 
-    <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_burger.urdf.xacro" />
-    <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf"  args="-urdf -model turtlebot3_burger -x $(arg init_x) -y $(arg init_y) -z 0 -param robot_description" />
+    <param name="robot_description" command="$(find xacro)/xacro $(find turtlebot3_description)/urdf/turtlebot3_waffle.urdf.xacro" />
+    <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf"  args="-urdf -model turtlebot3_waffle -x $(arg init_x) -y $(arg init_y) -z 0 -param robot_description" />
 
     <!-- for GT -->
 	<node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
@@ -49,10 +49,9 @@
     </node>
 	
 	<!--Start the Montecarlo Localization module-->
-    <arg name="initial_pose_y" default="0"/>
 	<node pkg="amcl" type="amcl" name="amcl" args="scan:=/scan">
-		<param name="initial_pose_x" value="0" /> 
-        <param name="initial_pose_y" value="$(arg initial_pose_y)" />
+		<param name="initial_pose_x" value="$(arg init_x" /> 
+        <param name="initial_pose_y" value="$(arg init_y)" />
 		<param name="initial_pose_a" value="0" />
 	</node>
 


### PR DESCRIPTION
Cambiado:

- "xacro --inorder" a solamente "xacro" (a partir de melodic no hay que poner --inorder)
- Modelo del robot "turtlebot3_burger" a "turtlebot3_waffle" que es el que hemos estado usando todo el tiempo hasta ahora.
- El punto de inicio para la localización de Montecarlo ahora toma los parámetros definidos por "init_x" e "init_y" (antes solo tomaba "initial_pose_y").